### PR TITLE
Update sizemapping builder

### DIFF
--- a/.changeset/breezy-lobsters-check.md
+++ b/.changeset/breezy-lobsters-check.md
@@ -1,0 +1,5 @@
+---
+"goopubtag": patch
+---
+
+This fixes a bug where the size mapping for responsive ads was not being defined properly

--- a/lib/components/GPTSlot/useGPTSlot.tsx
+++ b/lib/components/GPTSlot/useGPTSlot.tsx
@@ -38,11 +38,11 @@ const useGPTSlot = (props: UseGPTSlotProps) => {
 				}
 				if (unit !== null) {
 					if (sizeMapping) {
-						const mapping = gtag.getMapping();
+						const mappingBuilder = gtag.getMapping();
 						for (const { viewport, sizes } of sizeMapping) {
-							mapping.addSize(viewport, sizes);
+							mappingBuilder.addSize(viewport, sizes);
 						}
-						mapping.build();
+						const mapping = mappingBuilder.build();
 						unit.defineSizeMapping(mapping);
 					}
 

--- a/lib/constants/guidelines.ts
+++ b/lib/constants/guidelines.ts
@@ -19,7 +19,6 @@ const UNIT_SIZE = {
 	MOBILE_LEADERBOARD: [320, 50],
 	LINE_TEXT_UNIT: [280, 18],
 	ONE_BY_ONE: [1, 1],
-	BLANK: [0, 0],
 	FLUID: "fluid",
 } as const;
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -105,8 +105,8 @@ export type OutOfPage = Pick<SlotUnit, "adUnit" | "targetingArguments"> &
 	OutOfPageTypes;
 
 export type Mapping = {
-	addSize: (viewport: Size, sizes: Sizes) => void;
-	build: () => void;
+	addSize: (viewport: Size, sizes: Sizes) => Mapping;
+	build: () => Mapping;
 };
 
 /**

--- a/sandbox/vite-react/src/examples/AdSizes/AdSizes.tsx
+++ b/sandbox/vite-react/src/examples/AdSizes/AdSizes.tsx
@@ -42,7 +42,12 @@ const Component = () => {
 				<GPTSlot
 					adUnit="Travel/Europe"
 					slotId="multi-size-ad"
-					sizes={[UNIT_SIZE.MPU_300, UNIT_SIZE.LEADERBOARD, [750, 200]]}
+					sizes={[
+						UNIT_SIZE.MPU_300,
+						UNIT_SIZE.LEADERBOARD,
+						[750, 200],
+						UNIT_SIZE.FLUID,
+					]}
 				/>
 			</div>
 			<h1>Fluid ad slot</h1>
@@ -101,7 +106,7 @@ const Component = () => {
 						},
 						{
 							viewport: [0, 0],
-							sizes: UNIT_SIZE.BLANK,
+							sizes: [],
 						},
 					]}
 				/>


### PR DESCRIPTION
## Updates

- `mapping.build()` returns a value that needs to be passed to `defineSizeMapping`. 
- Updated the return type of `addSize` and `build` functions to reflect fix
- Removed `BLANK` guideline value as issues with readonly value being used (can simply use `[]` directly)
- Updated `AdSizes` example

fixes #17 