### PR TITLE
Reduce re-renders by removing `isLoaded` state

### DIFF
--- a/.changeset/gorgeous-flowers-relax.md
+++ b/.changeset/gorgeous-flowers-relax.md
@@ -1,0 +1,5 @@
+---
+"goopubtag": patch
+---
+
+Remove isLoading state, init googletag and cmd as recommended

--- a/lib/components/GPTProvider/GPTProvider.type.ts
+++ b/lib/components/GPTProvider/GPTProvider.type.ts
@@ -26,7 +26,6 @@ type SharedContextProps<PageAttributes extends Attributes = Attributes> =
 
 export type GPTContext<PageAttributes extends Attributes = Attributes> =
 	SharedContextProps<PageAttributes> & {
-		isLoaded: boolean;
 		addUnit: (unit: Unit) => void;
 		units: Unit[];
 	};

--- a/lib/components/GPTSlot/useGPTSlot.tsx
+++ b/lib/components/GPTSlot/useGPTSlot.tsx
@@ -20,93 +20,92 @@ const useGPTSlot = (props: UseGPTSlotProps) => {
 		fallback = "default",
 		outOfPage = false,
 	} = props;
-	const { networkId, units, isLoaded, lazyLoad, singleRequest, addUnit } =
+	const { networkId, units, lazyLoad, singleRequest, addUnit } =
 		useGPTContext();
 	const adUnitPath = gtag.getAdUnitPath(networkId, adUnit);
 
 	useEffect(() => {
-		if (isLoaded) {
-			gtag.push(() => {
-				let unit: Slot | null = null;
-				const isAlreadyDefined = units.find((u) => u.slotId === slotId);
+		gtag.init();
+		gtag.push(() => {
+			let unit: Slot | null = null;
+			const isAlreadyDefined = units.find((u) => u.slotId === slotId);
 
-				if (isAlreadyDefined) return;
+			if (isAlreadyDefined) return;
 
-				if (outOfPage) {
-					unit = gtag.createOutOfPageSlot(adUnitPath, slotId);
-				} else {
-					unit = gtag.createSlot(adUnitPath, sizes, slotId);
+			if (outOfPage) {
+				unit = gtag.createOutOfPageSlot(adUnitPath, slotId);
+			} else {
+				unit = gtag.createSlot(adUnitPath, sizes, slotId);
+			}
+			if (unit !== null) {
+				if (sizeMapping) {
+					const mappingBuilder = gtag.getMapping();
+					for (const { viewport, sizes } of sizeMapping) {
+						mappingBuilder.addSize(viewport, sizes);
+					}
+					const mapping = mappingBuilder.build();
+					unit.defineSizeMapping(mapping);
 				}
-				if (unit !== null) {
-					if (sizeMapping) {
-						const mappingBuilder = gtag.getMapping();
-						for (const { viewport, sizes } of sizeMapping) {
-							mappingBuilder.addSize(viewport, sizes);
-						}
-						const mapping = mappingBuilder.build();
-						unit.defineSizeMapping(mapping);
-					}
 
-					if (targetingArguments) {
-						for (const targetingKey of Object.keys(targetingArguments)) {
-							unit.setTargeting(targetingKey, targetingArguments[targetingKey]);
-						}
+				if (targetingArguments) {
+					for (const targetingKey of Object.keys(targetingArguments)) {
+						unit.setTargeting(targetingKey, targetingArguments[targetingKey]);
 					}
-					if (lazyLoad !== undefined) {
-						gtag.enableLazyLoad(lazyLoad);
-					}
-
-					if (onSlotLoad) {
-						subscribe("slot_load", (event) => {
-							const id = event.slot.getSlotElementId();
-							if (id === slotId) onSlotLoad(event);
-						});
-					}
-					if (onSlotRequested) {
-						subscribe("slot_requested", (event) => {
-							const id = event.slot.getSlotElementId();
-							if (id === slotId) onSlotRequested(event);
-						});
-					}
-					if (onSlotIsViewable) {
-						subscribe("impression_viewable", (event) => {
-							const id = event.slot.getSlotElementId();
-							if (id === slotId) onSlotIsViewable(event);
-						});
-					}
-					if (onSlotRenderEnded) {
-						subscribe("slot_render_ended", (event) => {
-							const id = event.slot.getSlotElementId();
-							if (id === slotId) onSlotRenderEnded(event);
-						});
-					}
-
-					if (fallback && fallback !== "default") {
-						switch (fallback) {
-							case "expand": {
-								unit.setCollapseEmptyDiv(true, true);
-								break;
-							}
-							case "expand_strict": {
-								unit.setCollapseEmptyDiv(false);
-								break;
-							}
-							case "collapse": {
-								unit.setCollapseEmptyDiv(true);
-								break;
-							}
-							default:
-								break;
-						}
-					}
-					slotId && addUnit({ slotId, unit });
-					if (singleRequest) {
-						gtag.enableSingleRequest();
-					}
-					gtag.enableService(slotId);
 				}
-			});
-		}
+				if (lazyLoad !== undefined) {
+					gtag.enableLazyLoad(lazyLoad);
+				}
+
+				if (onSlotLoad) {
+					subscribe("slot_load", (event) => {
+						const id = event.slot.getSlotElementId();
+						if (id === slotId) onSlotLoad(event);
+					});
+				}
+				if (onSlotRequested) {
+					subscribe("slot_requested", (event) => {
+						const id = event.slot.getSlotElementId();
+						if (id === slotId) onSlotRequested(event);
+					});
+				}
+				if (onSlotIsViewable) {
+					subscribe("impression_viewable", (event) => {
+						const id = event.slot.getSlotElementId();
+						if (id === slotId) onSlotIsViewable(event);
+					});
+				}
+				if (onSlotRenderEnded) {
+					subscribe("slot_render_ended", (event) => {
+						const id = event.slot.getSlotElementId();
+						if (id === slotId) onSlotRenderEnded(event);
+					});
+				}
+
+				if (fallback && fallback !== "default") {
+					switch (fallback) {
+						case "expand": {
+							unit.setCollapseEmptyDiv(true, true);
+							break;
+						}
+						case "expand_strict": {
+							unit.setCollapseEmptyDiv(false);
+							break;
+						}
+						case "collapse": {
+							unit.setCollapseEmptyDiv(true);
+							break;
+						}
+						default:
+							break;
+					}
+				}
+				slotId && addUnit({ slotId, unit });
+				if (singleRequest) {
+					gtag.enableSingleRequest();
+				}
+				gtag.enableService(slotId);
+			}
+		});
 
 		return () => {
 			/** Cleanup */
@@ -118,7 +117,6 @@ const useGPTSlot = (props: UseGPTSlotProps) => {
 				unsubscribe("slot_render_ended", onSlotRenderEnded);
 		};
 	}, [
-		isLoaded,
 		outOfPage,
 		targetingArguments,
 		sizeMapping,

--- a/lib/utils/gtag.ts
+++ b/lib/utils/gtag.ts
@@ -16,6 +16,11 @@ import type {
 	SlotViewableEvent,
 } from "../types";
 
+const init = (): void => {
+	window.googletag = window.googletag || ({} as unknown as GoogleTag);
+	window.googletag.cmd = window.googletag.cmd || [];
+};
+
 const push = (fn: () => void): void => {
 	window.googletag?.cmd.push(fn);
 };
@@ -189,6 +194,7 @@ const enableLazyLoad = (lazyLoad: boolean | LazyLoad): void => {
 };
 
 export const gtag = {
+	init,
 	push,
 	getAdUnitPath,
 	getTopAnchor,


### PR DESCRIPTION
As per google publisher documentation RE: `Avoiding Common Implementation Mistakes`

```txt
Assuming that the GPT API is ready to be called when the JavaScript file gpt.js is loaded is wrong, 
as some parts of the API are provided by the pubads_impl.js file. Relying in any way (including frameworks)
on the API from within event listeners attached to the script tag is therefore incorrect.
```

The recommended way is to ensure `googletag` exists on the window and that `cmd` exists as an array, before GPT takes over. Functionality pushed to `cmd` will be queued until the script has loaded.

Removing `isLoading` means one less re-render